### PR TITLE
Ignore log directory

### DIFF
--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Adding a blank .gitignore does not fully ignore all files in the directory. Fix this by adding these rules.